### PR TITLE
Stop blowing away the BufWritePre augroup in ftplugins

### DIFF
--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'css',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.css call prettier#Autoformat()
-augroup end

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'graphql',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.graphql,*.gql call prettier#Autoformat()
-augroup end

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -5,8 +5,3 @@ if expand('%:e') ==# 'html'
     \ 'parser': 'html',
     \ }
 endif
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.html call prettier#Autoformat()
-augroup end

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,4 +1,0 @@
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.js,*.jsx,*.mjs call prettier#Autoformat()
-augroup end

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'json',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.json call prettier#Autoformat()
-augroup end

--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'less',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.less call prettier#Autoformat()
-augroup end

--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'lua',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.lua call prettier#Autoformat()
-augroup end

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'markdown',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn call prettier#Autoformat()
-augroup end

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'php',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.php call prettier#Autoformat()
-augroup end

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'ruby',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.rb,*.ruby call prettier#Autoformat()
-augroup end

--- a/ftplugin/scss.vim
+++ b/ftplugin/scss.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'scss',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.scss call prettier#Autoformat()
-augroup end

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'typescript',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.ts,*.tsx call prettier#Autoformat()
-augroup end

--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'vue',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.vue call prettier#Autoformat()
-augroup end

--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -5,8 +5,3 @@ if expand('%:e') ==# 'xml'
     \ 'parser': 'xml',
     \ }
 endif
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.xml call prettier#Autoformat()
-augroup end

--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -1,8 +1,3 @@
 let b:prettier_ft_default_args = {
   \ 'parser': 'yaml',
   \ }
-
-augroup Prettier
-  autocmd!
-  autocmd BufWritePre *.yml,*.yaml call prettier#Autoformat()
-augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -174,5 +174,5 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html noautocmd | call prettier#Autoformat()
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.gql,*.markdown,*.md,*.mdown,*.mkd,*.mkdn,*.vue,*.yml,*.yaml,*.html,*.php,*.rb,*.ruby,*.xml noautocmd | call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
**Summary**

The `BufWritePre autocmds` are reset each time a file type plugin is run, which means if you open a file of one type, it will auto format correctly, but if you then open a file of a different type, the original file will no longer auto format.

See further explanation here: https://github.com/prettier/vim-prettier/issues/185#issuecomment-750987266

This PR removes the `augroup` from each of the ftplugin files and adds some missing file extensions to the `augroup` in `plugin/prettier.vim`.

**Test Plan**

[...]
